### PR TITLE
fix: 修复 chooseVideo 回调参数与文档不一致的问题

### DIFF
--- a/packages/taro-rn/src/lib/chooseVideo/index.ts
+++ b/packages/taro-rn/src/lib/chooseVideo/index.ts
@@ -1,4 +1,4 @@
-import { chooseMedia } from '../media'
+import { chooseMedia, MEDIA_TYPE } from '../media'
 
 /**
  * 拍摄视频或从手机相册中选视频。
@@ -10,5 +10,5 @@ import { chooseMedia } from '../media'
  * @returns {Promise<*>}
  */
 export function chooseVideo(opts: Taro.chooseVideo.Option): Promise<any> {
-  return chooseMedia(opts, 'Videos')
+  return chooseMedia(opts, MEDIA_TYPE.VIDEOS)
 }

--- a/packages/taro-rn/src/lib/media.ts
+++ b/packages/taro-rn/src/lib/media.ts
@@ -3,6 +3,11 @@ import { Permissions } from 'react-native-unimodules'
 import * as ImagePicker from 'expo-image-picker'
 import { askAsyncPermissions } from '../utils/premissions'
 
+export const MEDIA_TYPE = {
+  VIDEOS: 'Videos',
+  IMAGES: 'Images'
+}
+
 export async function saveMedia(opts: Taro.saveImageToPhotosAlbum.Option|Taro.saveVideoToPhotosAlbum.Option, type:string, API:string):Promise<Taro.General.CallbackResult> {
   const status = await askAsyncPermissions(Permissions.CAMERA_ROLL)
   if (status !== 'granted') {
@@ -49,16 +54,19 @@ export async function chooseMedia(opts: Taro.chooseImage.Option|Taro.chooseVideo
     p.then((resp) => {
       const { uri } = resp
       resp.path = uri
-      const res = {
+      let res = {
         tempFilePaths: [uri],
         tempFiles: [resp]
+      }
+      if (mediaTypes === MEDIA_TYPE.VIDEOS) {
+        res = Object.assign(res, { tempFilePath: uri })
       }
       success?.(res)
       complete?.(res)
       resolve(res as any)
     }).catch((err) => {
       const res = {
-        errMsg: 'chooseImage fail',
+        errMsg: mediaTypes === MEDIA_TYPE.VIDEOS ? 'chooseVideo fail' : 'chooseImage fail',
         err
       }
       fail?.(res)

--- a/packages/taro-rn/src/lib/scanCode/index.tsx
+++ b/packages/taro-rn/src/lib/scanCode/index.tsx
@@ -6,7 +6,7 @@ import iconClose from './icon_close.png'
 import iconPic from './icon_pic.png'
 import * as Permissions from 'expo-permissions'
 import RootSiblings from 'react-native-root-siblings'
-import { chooseMedia } from '../media'
+import { chooseMedia, MEDIA_TYPE } from '../media'
 import React from 'react'
 
 export let scannerView
@@ -141,7 +141,7 @@ function scanFromPhoto(callback, errorCallBack) {
         })
       }
     }
-  }, 'Images').catch(errorCallBack)
+  }, MEDIA_TYPE.IMAGES).catch(errorCallBack)
 }
 
 export async function scanCode(option: Taro.scanCode.Option = {}): Promise<Taro.scanCode.SuccessCallbackResult> {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复API chooseVideo 的 success 回调函数参数与文档不一致的问题：
文档：res.tempFilePath
实际：res.tempFilePaths
修复为：两者皆有

**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [X] 提交到 master 分支
- [X] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [X] 所有测试用例已经通过
- [X] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [X] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [X] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
