### PR TITLE
fix: 修复 swiper infinite 切换导致自动播放停止的问题

### DIFF
--- a/packages/taro-components-rn/src/components/Swiper/carousel.tsx
+++ b/packages/taro-components-rn/src/components/Swiper/carousel.tsx
@@ -112,8 +112,8 @@ class Carousel extends React.Component<CarouselProps, CarouselState> {
 
   componentDidUpdate(prevProps: CarouselProps) {
     if (
-      prevProps.autoplay !== undefined &&
-      prevProps.autoplay !== this.props.autoplay
+      (prevProps.autoplay !== undefined && prevProps.autoplay !== this.props.autoplay) ||
+      (prevProps.infinite !== undefined && prevProps.infinite !== this.props.infinite)
     ) {
       this.autoplay(!this.props.autoplay)
     }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

1、修复 swiper infinite 切换导致自动播放停止的问题：

问题：当自动播放及循环播放同时打开时，若关闭循环播放，当播放至最后一项时再打开，此时并没有预期中的继续播放。
修复：componentDidUpdate 控制组件更新时未考虑到 infinite。

**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [X] 提交到 master 分支
- [X] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [X] 所有测试用例已经通过
- [X] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [X] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] QQ 轻应用
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [X] 移动端（React-Native）

**其它需要 Reviewer 或社区知晓的内容：**
