### PR TITLE
fix: chooseImage 支持 sizeType 参数

### DIFF
--- a/packages/taro-rn/src/lib/chooseImage/index.ts
+++ b/packages/taro-rn/src/lib/chooseImage/index.ts
@@ -50,10 +50,12 @@ function openCamera(options: Taro.chooseImage.Option): Promise<Taro.chooseImage.
 }
 
 function openPicker(options: Taro.chooseImage.Option): Promise<Taro.chooseImage.SuccessCallbackResult> {
-  const { count: imageCount, success, complete, fail } = options
+  const { count: imageCount, sizeType = [],success, complete, fail } = options
   return new Promise((resolve, reject) => {
+    // NOTE：react-native-syan-image-picker 暂不支持 Android 端压缩
     SYImagePicker.showImagePicker({
       imageCount,
+      quality: sizeType[0] === 'compressed' ? 70 : 90,
     }, (err, photos: any) => {
       if (err) {
         const res = {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

1、Taro.chooseImage 支持 sizeType 属性，[issue](https://github.com/wuba/taro-react-native/issues/124)（[android 端不支持压缩](https://github.com/syanbo/react-native-syan-image-picker#%E9%85%8D%E7%BD%AE%E5%8F%82%E6%95%B0%E8%AF%B4%E6%98%8E)）；

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
